### PR TITLE
Move label gen from TexWidget to FieldTemplate for bootstrap4

### DIFF
--- a/packages/bootstrap-4/src/FieldTemplate/FieldTemplate.tsx
+++ b/packages/bootstrap-4/src/FieldTemplate/FieldTemplate.tsx
@@ -12,15 +12,30 @@ const FieldTemplate = ({
   rawErrors = [],
   rawHelp,
   rawDescription,
+  label,
+  schema,
+  required
 }: FieldTemplateProps) => {
+
+  const shouldDisplayLabel = displayLabel && (label || schema.title);
+  const labelComponent = shouldDisplayLabel
+    ? (
+      <Form.Label htmlFor={id} className={rawErrors.length > 0 ? "text-danger" : ""}>
+        {label || schema.title}
+        {required ? "*" : null}
+      </Form.Label>
+    )
+    : null;
+
   return (
     <Form.Group>
-      {children}
-      {displayLabel && rawDescription ? (
+      {labelComponent}
+      {shouldDisplayLabel && rawDescription ? (
         <Form.Text className={rawErrors.length > 0 ? "text-danger" : "text-muted"}>
           {rawDescription}
         </Form.Text>
       ) : null}
+      {children}
       {rawErrors.length > 0 && (
         <ListGroup as="ul">
           {rawErrors.map((error: string) => {

--- a/packages/bootstrap-4/src/TextWidget/TextWidget.tsx
+++ b/packages/bootstrap-4/src/TextWidget/TextWidget.tsx
@@ -11,7 +11,6 @@ const TextWidget = ({
   readonly,
   disabled,
   type,
-  label,
   value,
   onChange,
   onBlur,
@@ -35,11 +34,7 @@ const TextWidget = ({
 
   // const classNames = [rawErrors.length > 0 ? "is-invalid" : "", type === 'file' ? 'custom-file-label': ""]
   return (
-    <Form.Group className="mb-0">
-      <Form.Label className={rawErrors.length > 0 ? "text-danger" : ""}>
-        {label || schema.title}
-        {(label || schema.title) && required ? "*" : null}
-      </Form.Label>
+    <>
       <Form.Control
         id={id}
         placeholder={placeholder}
@@ -65,7 +60,7 @@ const TextWidget = ({
             })}
         </datalist>
       ) : null}
-    </Form.Group>
+    </>
   );
 };
 

--- a/packages/bootstrap-4/test/__snapshots__/Array.test.tsx.snap
+++ b/packages/bootstrap-4/test/__snapshots__/Array.test.tsx.snap
@@ -183,27 +183,20 @@ exports[`array fields fixed array 1`] = `
                   <div
                     className="form-group"
                   >
-                    <div
-                      className="mb-0 form-group"
-                    >
-                      <label
-                        className="form-label"
-                      />
-                      <input
-                        autoFocus={false}
-                        className="form-control"
-                        disabled={false}
-                        id="root_0"
-                        onBlur={[Function]}
-                        onChange={[Function]}
-                        onFocus={[Function]}
-                        placeholder=""
-                        readOnly={false}
-                        required={true}
-                        type="text"
-                        value=""
-                      />
-                    </div>
+                    <input
+                      autoFocus={false}
+                      className="form-control"
+                      disabled={false}
+                      id="root_0"
+                      onBlur={[Function]}
+                      onChange={[Function]}
+                      onFocus={[Function]}
+                      placeholder=""
+                      readOnly={false}
+                      required={true}
+                      type="text"
+                      value=""
+                    />
                   </div>
                 </div>
                 <div
@@ -221,27 +214,20 @@ exports[`array fields fixed array 1`] = `
                   <div
                     className="form-group"
                   >
-                    <div
-                      className="mb-0 form-group"
-                    >
-                      <label
-                        className="form-label"
-                      />
-                      <input
-                        autoFocus={false}
-                        className="form-control"
-                        disabled={false}
-                        id="root_1"
-                        onBlur={[Function]}
-                        onChange={[Function]}
-                        onFocus={[Function]}
-                        placeholder=""
-                        readOnly={false}
-                        required={true}
-                        type="number"
-                        value=""
-                      />
-                    </div>
+                    <input
+                      autoFocus={false}
+                      className="form-control"
+                      disabled={false}
+                      id="root_1"
+                      onBlur={[Function]}
+                      onChange={[Function]}
+                      onFocus={[Function]}
+                      placeholder=""
+                      readOnly={false}
+                      required={true}
+                      type="number"
+                      value=""
+                    />
                   </div>
                 </div>
                 <div

--- a/packages/bootstrap-4/test/__snapshots__/ColorWidget.test.tsx.snap
+++ b/packages/bootstrap-4/test/__snapshots__/ColorWidget.test.tsx.snap
@@ -1,28 +1,18 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`ColorWidget simple 1`] = `
-<div
-  className="mb-0 form-group"
->
-  <label
-    className="text-danger form-label"
-  >
-    Some simple label
-    *
-  </label>
-  <input
-    autoFocus={true}
-    className="is-invalid form-control"
-    disabled={false}
-    id="_id"
-    onBlur={[Function]}
-    onChange={[Function]}
-    onFocus={[Function]}
-    placeholder=""
-    readOnly={true}
-    required={true}
-    type="color"
-    value="value"
-  />
-</div>
+<input
+  autoFocus={true}
+  className="is-invalid form-control"
+  disabled={false}
+  id="_id"
+  onBlur={[Function]}
+  onChange={[Function]}
+  onFocus={[Function]}
+  placeholder=""
+  readOnly={true}
+  required={true}
+  type="color"
+  value="value"
+/>
 `;

--- a/packages/bootstrap-4/test/__snapshots__/DateTimeWidget.test.tsx.snap
+++ b/packages/bootstrap-4/test/__snapshots__/DateTimeWidget.test.tsx.snap
@@ -1,28 +1,18 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`DateTimeWidget simple 1`] = `
-<div
-  className="mb-0 form-group"
->
-  <label
-    className="text-danger form-label"
-  >
-    Some simple label
-    *
-  </label>
-  <input
-    autoFocus={true}
-    className="is-invalid form-control"
-    disabled={false}
-    id="_id"
-    onBlur={[Function]}
-    onChange={[Function]}
-    onFocus={[Function]}
-    placeholder=""
-    readOnly={true}
-    required={true}
-    type="datetime-local"
-    value="2020-07-30T13:41:00.268"
-  />
-</div>
+<input
+  autoFocus={true}
+  className="is-invalid form-control"
+  disabled={false}
+  id="_id"
+  onBlur={[Function]}
+  onChange={[Function]}
+  onFocus={[Function]}
+  placeholder=""
+  readOnly={true}
+  required={true}
+  type="datetime-local"
+  value="2020-07-30T13:41:00.268"
+/>
 `;

--- a/packages/bootstrap-4/test/__snapshots__/DateWidget.test.tsx.snap
+++ b/packages/bootstrap-4/test/__snapshots__/DateWidget.test.tsx.snap
@@ -1,28 +1,18 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`DateWidget simple 1`] = `
-<div
-  className="mb-0 form-group"
->
-  <label
-    className="text-danger form-label"
-  >
-    Some simple label
-    *
-  </label>
-  <input
-    autoFocus={true}
-    className="is-invalid form-control"
-    disabled={false}
-    id="_id"
-    onBlur={[Function]}
-    onChange={[Function]}
-    onFocus={[Function]}
-    placeholder=""
-    readOnly={true}
-    required={true}
-    type="date"
-    value="value"
-  />
-</div>
+<input
+  autoFocus={true}
+  className="is-invalid form-control"
+  disabled={false}
+  id="_id"
+  onBlur={[Function]}
+  onChange={[Function]}
+  onFocus={[Function]}
+  placeholder=""
+  readOnly={true}
+  required={true}
+  type="date"
+  value="value"
+/>
 `;

--- a/packages/bootstrap-4/test/__snapshots__/Form.test.tsx.snap
+++ b/packages/bootstrap-4/test/__snapshots__/Form.test.tsx.snap
@@ -229,26 +229,19 @@ exports[`single fields format color 1`] = `
   <div
     className="form-group"
   >
-    <div
-      className="mb-0 form-group"
-    >
-      <label
-        className="form-label"
-      />
-      <input
-        autoFocus={false}
-        className="form-control"
-        disabled={false}
-        id="root"
-        onBlur={[Function]}
-        onChange={[Function]}
-        onFocus={[Function]}
-        placeholder=""
-        readOnly={false}
-        type="color"
-        value=""
-      />
-    </div>
+    <input
+      autoFocus={false}
+      className="form-control"
+      disabled={false}
+      id="root"
+      onBlur={[Function]}
+      onChange={[Function]}
+      onFocus={[Function]}
+      placeholder=""
+      readOnly={false}
+      type="color"
+      value=""
+    />
   </div>
   <div>
     <button
@@ -271,26 +264,19 @@ exports[`single fields format date 1`] = `
   <div
     className="form-group"
   >
-    <div
-      className="mb-0 form-group"
-    >
-      <label
-        className="form-label"
-      />
-      <input
-        autoFocus={false}
-        className="form-control"
-        disabled={false}
-        id="root"
-        onBlur={[Function]}
-        onChange={[Function]}
-        onFocus={[Function]}
-        placeholder=""
-        readOnly={false}
-        type="date"
-        value=""
-      />
-    </div>
+    <input
+      autoFocus={false}
+      className="form-control"
+      disabled={false}
+      id="root"
+      onBlur={[Function]}
+      onChange={[Function]}
+      onFocus={[Function]}
+      placeholder=""
+      readOnly={false}
+      type="date"
+      value=""
+    />
   </div>
   <div>
     <button
@@ -313,26 +299,19 @@ exports[`single fields format datetime 1`] = `
   <div
     className="form-group"
   >
-    <div
-      className="mb-0 form-group"
-    >
-      <label
-        className="form-label"
-      />
-      <input
-        autoFocus={false}
-        className="form-control"
-        disabled={false}
-        id="root"
-        onBlur={[Function]}
-        onChange={[Function]}
-        onFocus={[Function]}
-        placeholder=""
-        readOnly={false}
-        type="datetime-local"
-        value=""
-      />
-    </div>
+    <input
+      autoFocus={false}
+      className="form-control"
+      disabled={false}
+      id="root"
+      onBlur={[Function]}
+      onChange={[Function]}
+      onFocus={[Function]}
+      placeholder=""
+      readOnly={false}
+      type="datetime-local"
+      value=""
+    />
   </div>
   <div>
     <button
@@ -373,6 +352,12 @@ exports[`single fields hidden field 1`] = `
           <div
             className="form-group"
           >
+            <label
+              className="form-label"
+              htmlFor="root_my-field"
+            >
+              my-field
+            </label>
             <input
               id="root_my-field"
               type="hidden"
@@ -425,26 +410,19 @@ exports[`single fields number field 0 1`] = `
   <div
     className="form-group"
   >
-    <div
-      className="mb-0 form-group"
-    >
-      <label
-        className="form-label"
-      />
-      <input
-        autoFocus={false}
-        className="form-control"
-        disabled={false}
-        id="root"
-        onBlur={[Function]}
-        onChange={[Function]}
-        onFocus={[Function]}
-        placeholder=""
-        readOnly={false}
-        type="number"
-        value={0}
-      />
-    </div>
+    <input
+      autoFocus={false}
+      className="form-control"
+      disabled={false}
+      id="root"
+      onBlur={[Function]}
+      onChange={[Function]}
+      onFocus={[Function]}
+      placeholder=""
+      readOnly={false}
+      type="number"
+      value={0}
+    />
   </div>
   <div>
     <button
@@ -467,26 +445,19 @@ exports[`single fields number field 1`] = `
   <div
     className="form-group"
   >
-    <div
-      className="mb-0 form-group"
-    >
-      <label
-        className="form-label"
-      />
-      <input
-        autoFocus={false}
-        className="form-control"
-        disabled={false}
-        id="root"
-        onBlur={[Function]}
-        onChange={[Function]}
-        onFocus={[Function]}
-        placeholder=""
-        readOnly={false}
-        type="number"
-        value=""
-      />
-    </div>
+    <input
+      autoFocus={false}
+      className="form-control"
+      disabled={false}
+      id="root"
+      onBlur={[Function]}
+      onChange={[Function]}
+      onFocus={[Function]}
+      placeholder=""
+      readOnly={false}
+      type="number"
+      value=""
+    />
   </div>
   <div>
     <button
@@ -685,26 +656,19 @@ exports[`single fields string field format data-url 1`] = `
   <div
     className="form-group"
   >
-    <div
-      className="mb-0 form-group"
-    >
-      <label
-        className="form-label"
-      />
-      <input
-        autoFocus={false}
-        className="form-control-file"
-        disabled={false}
-        id="root"
-        onBlur={[Function]}
-        onChange={[Function]}
-        onFocus={[Function]}
-        placeholder=""
-        readOnly={false}
-        type="file"
-        value=""
-      />
-    </div>
+    <input
+      autoFocus={false}
+      className="form-control-file"
+      disabled={false}
+      id="root"
+      onBlur={[Function]}
+      onChange={[Function]}
+      onFocus={[Function]}
+      placeholder=""
+      readOnly={false}
+      type="file"
+      value=""
+    />
   </div>
   <div>
     <button
@@ -727,26 +691,19 @@ exports[`single fields string field format email 1`] = `
   <div
     className="form-group"
   >
-    <div
-      className="mb-0 form-group"
-    >
-      <label
-        className="form-label"
-      />
-      <input
-        autoFocus={false}
-        className="form-control"
-        disabled={false}
-        id="root"
-        onBlur={[Function]}
-        onChange={[Function]}
-        onFocus={[Function]}
-        placeholder=""
-        readOnly={false}
-        type="email"
-        value=""
-      />
-    </div>
+    <input
+      autoFocus={false}
+      className="form-control"
+      disabled={false}
+      id="root"
+      onBlur={[Function]}
+      onChange={[Function]}
+      onFocus={[Function]}
+      placeholder=""
+      readOnly={false}
+      type="email"
+      value=""
+    />
   </div>
   <div>
     <button
@@ -769,26 +726,19 @@ exports[`single fields string field format uri 1`] = `
   <div
     className="form-group"
   >
-    <div
-      className="mb-0 form-group"
-    >
-      <label
-        className="form-label"
-      />
-      <input
-        autoFocus={false}
-        className="form-control"
-        disabled={false}
-        id="root"
-        onBlur={[Function]}
-        onChange={[Function]}
-        onFocus={[Function]}
-        placeholder=""
-        readOnly={false}
-        type="url"
-        value=""
-      />
-    </div>
+    <input
+      autoFocus={false}
+      className="form-control"
+      disabled={false}
+      id="root"
+      onBlur={[Function]}
+      onChange={[Function]}
+      onFocus={[Function]}
+      placeholder=""
+      readOnly={false}
+      type="url"
+      value=""
+    />
   </div>
   <div>
     <button
@@ -811,26 +761,19 @@ exports[`single fields string field regular 1`] = `
   <div
     className="form-group"
   >
-    <div
-      className="mb-0 form-group"
-    >
-      <label
-        className="form-label"
-      />
-      <input
-        autoFocus={false}
-        className="form-control"
-        disabled={false}
-        id="root"
-        onBlur={[Function]}
-        onChange={[Function]}
-        onFocus={[Function]}
-        placeholder=""
-        readOnly={false}
-        type="text"
-        value=""
-      />
-    </div>
+    <input
+      autoFocus={false}
+      className="form-control"
+      disabled={false}
+      id="root"
+      onBlur={[Function]}
+      onChange={[Function]}
+      onFocus={[Function]}
+      placeholder=""
+      readOnly={false}
+      type="text"
+      value=""
+    />
   </div>
   <div>
     <button
@@ -853,26 +796,19 @@ exports[`single fields string field with placeholder 1`] = `
   <div
     className="form-group"
   >
-    <div
-      className="mb-0 form-group"
-    >
-      <label
-        className="form-label"
-      />
-      <input
-        autoFocus={false}
-        className="form-control"
-        disabled={false}
-        id="root"
-        onBlur={[Function]}
-        onChange={[Function]}
-        onFocus={[Function]}
-        placeholder="placeholder"
-        readOnly={false}
-        type="text"
-        value=""
-      />
-    </div>
+    <input
+      autoFocus={false}
+      className="form-control"
+      disabled={false}
+      id="root"
+      onBlur={[Function]}
+      onChange={[Function]}
+      onFocus={[Function]}
+      placeholder="placeholder"
+      readOnly={false}
+      type="text"
+      value=""
+    />
   </div>
   <div>
     <button

--- a/packages/bootstrap-4/test/__snapshots__/Object.test.tsx.snap
+++ b/packages/bootstrap-4/test/__snapshots__/Object.test.tsx.snap
@@ -27,29 +27,26 @@ exports[`object fields object 1`] = `
           <div
             className="form-group"
           >
-            <div
-              className="mb-0 form-group"
+            <label
+              className="form-label"
+              htmlFor="root_a"
             >
-              <label
-                className="form-label"
-              >
-                a
-              </label>
-              <input
-                autoFocus={false}
-                className="form-control"
-                disabled={false}
-                id="root_a"
-                onBlur={[Function]}
-                onChange={[Function]}
-                onFocus={[Function]}
-                placeholder=""
-                readOnly={false}
-                required={false}
-                type="text"
-                value=""
-              />
-            </div>
+              a
+            </label>
+            <input
+              autoFocus={false}
+              className="form-control"
+              disabled={false}
+              id="root_a"
+              onBlur={[Function]}
+              onChange={[Function]}
+              onFocus={[Function]}
+              placeholder=""
+              readOnly={false}
+              required={false}
+              type="text"
+              value=""
+            />
           </div>
         </div>
       </div>
@@ -68,29 +65,26 @@ exports[`object fields object 1`] = `
           <div
             className="form-group"
           >
-            <div
-              className="mb-0 form-group"
+            <label
+              className="form-label"
+              htmlFor="root_b"
             >
-              <label
-                className="form-label"
-              >
-                b
-              </label>
-              <input
-                autoFocus={false}
-                className="form-control"
-                disabled={false}
-                id="root_b"
-                onBlur={[Function]}
-                onChange={[Function]}
-                onFocus={[Function]}
-                placeholder=""
-                readOnly={false}
-                required={false}
-                type="number"
-                value=""
-              />
-            </div>
+              b
+            </label>
+            <input
+              autoFocus={false}
+              className="form-control"
+              disabled={false}
+              id="root_b"
+              onBlur={[Function]}
+              onChange={[Function]}
+              onFocus={[Function]}
+              placeholder=""
+              readOnly={false}
+              required={false}
+              type="number"
+              value=""
+            />
           </div>
         </div>
       </div>

--- a/packages/bootstrap-4/test/__snapshots__/TextWidget.test.tsx.snap
+++ b/packages/bootstrap-4/test/__snapshots__/TextWidget.test.tsx.snap
@@ -1,28 +1,18 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`TextWidget simple 1`] = `
-<div
-  className="mb-0 form-group"
->
-  <label
-    className="text-danger form-label"
-  >
-    Some simple label
-    *
-  </label>
-  <input
-    autoFocus={true}
-    className="is-invalid form-control"
-    disabled={false}
-    id="_id"
-    onBlur={[Function]}
-    onChange={[Function]}
-    onFocus={[Function]}
-    placeholder=""
-    readOnly={true}
-    required={true}
-    type="array"
-    value="value"
-  />
-</div>
+<input
+  autoFocus={true}
+  className="is-invalid form-control"
+  disabled={false}
+  id="_id"
+  onBlur={[Function]}
+  onChange={[Function]}
+  onFocus={[Function]}
+  placeholder=""
+  readOnly={true}
+  required={true}
+  type="array"
+  value="value"
+/>
 `;


### PR DESCRIPTION
### Reasons for making this change

1. The current code for FieldTemplate and TextWidget in bootstrap 4 is incompatible with the core package. This breaks the 
external facing API for customizing field template. 
If a user uses custom field template with the bootstrap 4 form, the label is displayed multiple times, once by the custom field template (as intended in the API) and second time by the TextWidget (breaks from the core package convention)

If this is related to existing tickets, include links to them as well. Use the syntax `fixes #[issue number]` (ex: `fixes #123`).

### Checklist

* [ ] **I'm updating documentation**
  - [x] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
* [x] **I'm adding or updating code**
  - [x] I've added and/or updated tests
  - [x] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature

Since this is a bug fix, no docs need to be updated, docs already provide the correct information on how to use custom field templates.

I have updated all the tests

### Test from Playground
![Screen Shot 2021-09-01 at 2 14 25 PM](https://user-images.githubusercontent.com/42853152/131767016-ff74dd6a-6588-4cbe-a58c-5956d9b2714a.png)

### All tests passing
![Screen Shot 2021-09-01 at 6 20 44 PM](https://user-images.githubusercontent.com/42853152/131767060-cef93283-3190-470b-b107-ab0716ecbabd.png)
![Screen Shot 2021-09-01 at 6 22 03 PM](https://user-images.githubusercontent.com/42853152/131767074-8344c462-adf1-49dc-b09f-e776f95b2d4a.png)

